### PR TITLE
Add Gen-Z anonymizer endpoint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           python -m venv env
           source env/bin/activate
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Wait for services to be ready
         run: sleep 60
@@ -142,6 +143,7 @@ jobs:
         working-directory: e2e-tests
         run: |
           source env/bin/activate
+          pytest tests/test_api_anonymizer.py -vv
 
       - name: Stop Docker containers
         if: always()

--- a/e2e-tests/common/methods.py
+++ b/e2e-tests/common/methods.py
@@ -19,14 +19,19 @@ def anonymize(data):
     )
     return response.status_code, response.content
 
+def anonymize_genz(data):
+    response = requests.post(
+        f"{ANONYMIZER_BASE_URL}/genz",
+        json=data, 
+        headers=DEFAULT_HEADERS
+    )
+    return response.status_code, response.content
 
 def anonymizers():
     response = requests.get(
         f"{ANONYMIZER_BASE_URL}/anonymizers", headers=DEFAULT_HEADERS
     )
     return response.status_code, response.content
-
-
 
 def deanonymize(data):
     response = requests.post(

--- a/e2e-tests/tests/test_api_anonymizer.py
+++ b/e2e-tests/tests/test_api_anonymizer.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from common.assertions import equal_json_strings
-from common.methods import anonymize, anonymizers, deanonymize
+from common.methods import anonymize, anonymizers, deanonymize, anonymize_genz
 
 
 @pytest.mark.api
@@ -401,3 +401,38 @@ def test_overlapping_keep_both():
 
     assert response_status == 200
     assert equal_json_strings(expected_response, response_content)
+
+@pytest.mark.api
+def test_given_anonymize_called_with_genz_then_expected_valid_response_returned():
+    request_body = {
+        "text": "Please contact Emily Carter at 734-555-9284 if you have questions about the workshop registration.",
+        "analyzer_results": [
+            {
+                "start": 15,
+                "end": 27,
+                "score": 0.3,
+                "entity_type": "PERSON"
+            },
+            {
+                "start": 31,
+                "end": 43,
+                "score": 0.95,
+                "entity_type": "PHONE_NUMBER"
+            }
+        ]
+    }
+
+    response_status, response_content = anonymize_genz(request_body)
+
+    response_json = json.loads(response_content)
+
+    # Check status code
+    assert response_status == 200
+
+    assert "text" in response_json
+    assert "items" in response_json
+    assert isinstance(response_json["items"], list)
+
+    entity_types = [item["entity_type"] for item in response_json["items"]]
+    assert "PERSON" in entity_types
+    assert "PHONE_NUMBER" in entity_types

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -95,6 +95,15 @@ class Server:
         def deanonymizers():
             """Return a list of supported deanonymizers."""
             return jsonify(self.deanonymize.get_deanonymizers())
+        
+        @self.app.route("/genz-preview", methods=["GET"])
+        def genz_preview():
+            response = {
+                "example": "Call Emily at 577-988-1234",
+                "example output": "Call GOAT at vibe check",
+                "description": "Example output of the genz anonymizer."
+            }
+            return jsonify(response)
 
         @self.app.errorhandler(InvalidParamError)
         def invalid_param(err):
@@ -111,6 +120,7 @@ class Server:
         def server_error(e):
             self.logger.error(f"A fatal error occurred during execution: {e}")
             return jsonify(error="Internal server error"), 500
+
 
 def create_app(): # noqa
     server = Server()

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -1,8 +1,8 @@
 """REST API server for anonymizer."""
 
 import logging
-import os
 from logging.config import fileConfig
+import os
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -6,11 +6,12 @@ from logging.config import fileConfig
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
-from presidio_anonymizer import AnonymizerEngine, DeanonymizeEngine
-from presidio_anonymizer.operators.genz import GenZ
-from presidio_anonymizer.entities import InvalidParamError, OperatorConfig
-from presidio_anonymizer.services.app_entities_convertor import AppEntitiesConvertor
 from werkzeug.exceptions import BadRequest, HTTPException
+
+from presidio_anonymizer import AnonymizerEngine, DeanonymizeEngine
+from presidio_anonymizer.entities import InvalidParamError, OperatorConfig
+from presidio_anonymizer.operators.genz import GenZ
+from presidio_anonymizer.services.app_entities_convertor import AppEntitiesConvertor
 
 DEFAULT_PORT = "3000"
 
@@ -97,7 +98,7 @@ class Server:
         def deanonymizers():
             """Return a list of supported deanonymizers."""
             return jsonify(self.deanonymize.get_deanonymizers())
-        
+
         @self.app.route("/genz-preview", methods=["GET"])
         def genz_preview():
             response = {
@@ -106,25 +107,23 @@ class Server:
                 "description": "Example output of the genz anonymizer."
             }
             return jsonify(response)
-        
+
         @self.app.route("/genz", methods=["POST"])
         def genz():
             content = request.get_json()
             if not content:
                 raise BadRequest("Invalid request JSON")
-
             text = content.get("text", "")
             analyzer_results = AppEntitiesConvertor.analyzer_results_from_json(
                 content.get("analyzer_results", [])
             )
-
-            # Use the Gen-Z operator
             genz_result = self.anonymizer.anonymize(
                 text=text,
                 analyzer_results=analyzer_results,
-                operators={"PERSON": OperatorConfig("genz"), "PHONE_NUMBER": OperatorConfig("genz")} 
+                operators={"PERSON": OperatorConfig("genz"),
+                           "PHONE_NUMBER": OperatorConfig("genz")
+                }
             )
-
             return Response(genz_result.to_json(), mimetype="application/json")
 
         @self.app.errorhandler(InvalidParamError)

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -6,12 +6,11 @@ import os
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
-from werkzeug.exceptions import BadRequest, HTTPException
-
 from presidio_anonymizer import AnonymizerEngine, DeanonymizeEngine
 from presidio_anonymizer.entities import InvalidParamError, OperatorConfig
 from presidio_anonymizer.operators.genz import GenZ
 from presidio_anonymizer.services.app_entities_convertor import AppEntitiesConvertor
+from werkzeug.exceptions import BadRequest, HTTPException
 
 DEFAULT_PORT = "3000"
 

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -1,8 +1,8 @@
 """REST API server for anonymizer."""
 
 import logging
-from logging.config import fileConfig
 import os
+from logging.config import fileConfig
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
 from presidio_anonymizer import AnonymizerEngine, DeanonymizeEngine
-from presidio_anonymizer.entities import InvalidParamError
+from presidio_anonymizer.operators.genz import GenZ
+from presidio_anonymizer.entities import InvalidParamError, OperatorConfig
 from presidio_anonymizer.services.app_entities_convertor import AppEntitiesConvertor
 from werkzeug.exceptions import BadRequest, HTTPException
 
@@ -38,6 +39,7 @@ class Server:
         self.logger.info("Starting anonymizer engine")
         self.anonymizer = AnonymizerEngine()
         self.deanonymize = DeanonymizeEngine()
+        self.anonymizer.add_anonymizer(GenZ)
         self.logger.info(WELCOME_MESSAGE)
 
         @self.app.route("/health")
@@ -104,6 +106,26 @@ class Server:
                 "description": "Example output of the genz anonymizer."
             }
             return jsonify(response)
+        
+        @self.app.route("/genz", methods=["POST"])
+        def genz():
+            content = request.get_json()
+            if not content:
+                raise BadRequest("Invalid request JSON")
+
+            text = content.get("text", "")
+            analyzer_results = AppEntitiesConvertor.analyzer_results_from_json(
+                content.get("analyzer_results", [])
+            )
+
+            # Use the Gen-Z operator
+            genz_result = self.anonymizer.anonymize(
+                text=text,
+                analyzer_results=analyzer_results,
+                operators={"PERSON": OperatorConfig("genz"), "PHONE_NUMBER": OperatorConfig("genz")} 
+            )
+
+            return Response(genz_result.to_json(), mimetype="application/json")
 
         @self.app.errorhandler(InvalidParamError)
         def invalid_param(err):


### PR DESCRIPTION
### Overview
This PR adds a new Gen-Z anonymizer feature to the Presidio-Anonymizer REST API.

### Changes
- Added `/genz-preview` GET endpoint with example Gen-Z output.
- Added `/genz` POST endpoint that anonymizes text using the Gen-Z operator.
- Added end-to-end test for the `/genz` endpoint.
- Updated GitHub Actions workflow to run E2E tests in CI.

### Testing
- Manual testing via Postman:
  - `GET /genz-preview` returns example JSON.
  - `POST /genz` returns anonymized text.
- End-to-end tests pass locally and in CI.

### Notes
- Input/output formats match existing `/anonymize` endpoint.
